### PR TITLE
Update: MAC config in the script not needed and permissions checked

### DIFF
--- a/base_external/rootfs_overlay_beaglebone/etc/init.d/S30usbgadget
+++ b/base_external/rootfs_overlay_beaglebone/etc/init.d/S30usbgadget
@@ -30,7 +30,6 @@ mkdir configs/c.1
 mkdir configs/c.1/strings/0x409
 echo Conf 1 > configs/c.1/strings/0x409/configuration
 echo 120 > configs/c.1/MaxPower
-echo "06:32:9b:a9:9d:a5" > functions/ecm.usb0/host_addr
 ln -s functions/ecm.usb0 configs/c.1
 echo musb-hdrc.0 > UDC
 cd ${OLDPWD}


### PR DESCRIPTION
Solution for USB gadget related SSH issue. Permissions for  S30usbgadget script changed and MAC address configuration not required, hence removed.